### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # HaoRefresh
 仿知乎列表效果（含下拉刷新加载更多）
 
-##HaoRecyclerView使用说明
+## HaoRecyclerView使用说明
 
-###已上传jcenter
+### 已上传jcenter
 引入方式：compile 'com.github.fangx:haorefresh:1.0'
 
 
-###控件支持各种扩展
+### 控件支持各种扩展
 1. 可自己集成下拉刷新效果,可用系统的下拉组件或者参考[下拉刷新效果](https://github.com/liaohuqiu/android-Ultra-Pull-To-Refresh)
 2. 可自定义底部加载更多效果，setFootLoadingView(view); [加载中效果](https://github.com/81813780/AVLoadingIndicatorView)
 3. 可自定义没有更多数据效果，setFootEndView(view);
 
 
-##列表刷新效果
+## 列表刷新效果
   包含下拉刷新及加载更多
   
 ![](https://github.com/fangx/HaoRefresh/blob/master/zhihu_refresh.gif)
 
-##条目点击效果
+## 条目点击效果
 
 ![](https://github.com/fangx/HaoRefresh/blob/master/zhihu_click.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
